### PR TITLE
Fix for failed prop-type warning for component

### DIFF
--- a/src/baseModalProvider.js
+++ b/src/baseModalProvider.js
@@ -49,7 +49,9 @@ BaseModalProvider.propTypes = {
         id: PropTypes.number.isRequired,
         component: PropTypes.oneOfType([
           PropTypes.element,
-          PropTypes.func
+          PropTypes.func,
+          PropTypes.node,
+          PropTypes.elementType
         ]).isRequired,
         props: PropTypes.object,
         show: PropTypes.bool.isRequired,


### PR DESCRIPTION
Hi, I'm create a modal layout using hooks and rbx (Bulma), and every time the modal is showed the message below appears.

Warning: Failed prop type: Invalid prop `modalProvider.stack[0].component` supplied to `SingleModalProvider`.

With this fix on prop-types, the message disappears.